### PR TITLE
adds /admin scope to some routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,28 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :topics
-  resources :organizers do
+
+  scope '/admin' do
+    resources :topics, only: [:edit, :new]
+    resources :organizers, only: [:edit, :new]
+    resources :locations, only: [:edit, :new]
+    resources :opportunities, only: [:edit, :new]
+    resources :opportunity_instances, only: [:edit, :new]
+  end
+
+  resources :topics, except: [:edit, :new]
+  resources :locations, except: [:edit, :new]
+  resources :opportunities, except: [:edit, :new]
+
+  resources :organizers, except: [:edit, :new] do
     resources :opportunities
   end
-  resources :locations
-  resources :opportunities
-  resources :opportunity_instances do
+
+  resources :opportunity_instances, except: [:edit, :new] do
     collection do
       get 'topics/:title', action: :topic
       get 'search/:term', action: :search
     end
   end
+
   root 'application#hello'
 end


### PR DESCRIPTION
@justinxreese: I just used `scope` instead of adding `namespace` so I didn't have to separate out the controller functions. Let me know if you want me to actually `namespace` it and separate out the controllers.
